### PR TITLE
chore: phase 3 — enforce quality gates and branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Default reviewers — replace @geminislabs/engineering with your GitHub team slug
+* @geminislabs/engineering
+
+# Authentication and session handling
+/src/lib/services/authService.js @geminislabs/engineering
+/src/lib/services/apiClient.js @geminislabs/engineering
+/src/lib/services/sessionExpiredHandler.js @geminislabs/engineering
+/src/lib/stores/authStore.js @geminislabs/engineering
+/src/routes/auth/ @geminislabs/engineering
+
+# Billing and payments
+/src/lib/services/billingService.js @geminislabs/engineering
+/src/routes/control-panel/billing/ @geminislabs/engineering
+
+# CI/CD and release
+/.github/workflows/ @geminislabs/engineering
+/scripts/ @geminislabs/engineering
+/Dockerfile @geminislabs/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,5 +14,6 @@
 
 # CI/CD and release
 /.github/workflows/ @geminislabs/engineering
+/.github/dependabot.yml @geminislabs/engineering
 /scripts/ @geminislabs/engineering
 /Dockerfile @geminislabs/engineering

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,118 @@
+# Dependabot — automated dependency updates
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# PRs target `develop`. CI (quality, security, e2e) must pass before merge.
+# Security advisories also open PRs automatically when vulnerability alerts are enabled.
+
+version: 2
+updates:
+  # npm — SvelteKit, Vite, Vitest, Playwright, etc.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: America/Mexico_City
+    target-branch: develop
+    versioning-strategy: increase
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - npm
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      # Patch/minor batched by area; major versions stay as individual PRs for review.
+      svelte-ecosystem:
+        patterns:
+          - '@sveltejs/*'
+          - 'svelte'
+          - 'svelte-check'
+        update-types:
+          - minor
+          - patch
+      vite-vitest:
+        patterns:
+          - 'vite'
+          - 'vitest'
+          - '@vitest/*'
+          - 'vitest-*'
+        update-types:
+          - minor
+          - patch
+      playwright:
+        patterns:
+          - 'playwright'
+          - '@playwright/*'
+        update-types:
+          - minor
+          - patch
+      tailwind:
+        patterns:
+          - 'tailwindcss'
+          - '@tailwindcss/*'
+          - 'prettier-plugin-tailwindcss'
+        update-types:
+          - minor
+          - patch
+      lint-format:
+        patterns:
+          - 'eslint*'
+          - '@eslint/*'
+          - 'prettier*'
+          - 'lint-staged'
+          - '@commitlint/*'
+        update-types:
+          - minor
+          - patch
+      production-deps:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-tooling:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions — checkout, setup-node, upload-artifact, semgrep, etc.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: America/Mexico_City
+    target-branch: develop
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+
+  # Docker base images — Dockerfile, Dockerfile.simple, Dockerfile.fallback
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: America/Mexico_City
+    target-branch: develop
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,18 +40,24 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
+
       - name: Build application
         env:
           VITE_RECAPTCHA_SITE_KEY: ${{ vars.VITE_RECAPTCHA_SITE_KEY }}
         run: npm run build
 
       - name: Audit dependencies
-        continue-on-error: true
         run: npm run audit
 
   e2e:
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout code
@@ -93,3 +99,6 @@ jobs:
             p/javascript
             p/typescript
             p/secrets
+
+      - name: OSV dependency scan
+        run: bash scripts/osv-scan.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Antes de modificar integraciones con backend, lee `docs/architecture/modules/REA
 npm run validate
 ```
 
-Equivalente: `npm run lint`, `npm run check`, `npm run test`, `npm run build`.
+Equivalente: `npm run lint`, `npm run check`, `npm run test:coverage`, `npm run build`.
 
 Si tocaste `src/lib/**`, verifica cobertura:
 
@@ -54,7 +54,7 @@ Si tocaste `src/lib/**`, verifica cobertura:
 npm run test:coverage
 ```
 
-Umbrales objetivo (`src/lib/` servicios, stores, utils, config): 70% líneas/funciones/statements, 60% ramas. Verificar con `npm run test:coverage`.
+Umbrales en CI (`src/lib/` servicios, stores, utils, config): **90%** líneas/funciones/statements, **70%** ramas. Ver `vite.config.js` y `docs/GOVERNANCE.md`.
 
 ## Módulos sensibles
 
@@ -92,7 +92,7 @@ Referencias en `README.md` y `.env.example` si existe.
 
 - **Changelog:** `CHANGELOG.md` — actualizar `[Unreleased]` en PRs con cambios de release note
 - **Pre-push:** valida rama (`feature/`, `fix/`, `chore/`, etc.) y presencia de changelog vs `origin/develop`
-- **CI:** `.github/workflows/ci.yml` — lint, check, coverage, build, audit, Gitleaks, Semgrep
+- **CI:** `.github/workflows/ci.yml` — lint, check, coverage (umbrales), build, audit, e2e, Gitleaks, Semgrep, OSV-Scanner
 - **Deploy:** `.github/workflows/deploy.yml` — solo tags `v*.*.*`; ver [docs/RELEASE.md](docs/RELEASE.md)
 
 ## PRs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Phase 3 quality gates: coverage thresholds (90% lines/statements/functions on `src/lib/**`), blocking e2e and audit CI jobs
+- Dependabot version updates for npm, GitHub Actions, and Docker (`.github/dependabot.yml`)
 - OSV-Scanner dependency scan (`scripts/osv-scan.sh`, `npm run scan:osv`)
 - `.github/CODEOWNERS` and `docs/GOVERNANCE.md` (branch protection checklist)
 - Coverage artifact upload in CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Phase 3 quality gates: coverage thresholds (90% lines/statements/functions on `src/lib/**`), blocking e2e and audit CI jobs
+- OSV-Scanner dependency scan (`scripts/osv-scan.sh`, `npm run scan:osv`)
+- `.github/CODEOWNERS` and `docs/GOVERNANCE.md` (branch protection checklist)
+- Coverage artifact upload in CI
+- Expanded unit tests for services, stores, and utils (~150 tests)
 - Engineering foundation docs: `AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md`, `.editorconfig`, `.nvmrc`
-- Release discipline: `CHANGELOG.md`, `docs/RELEASE.md`, `scripts/setup.sh`, pre-push hooks
+
+### Changed
+
+- `npm run validate` now runs `test:coverage` with enforced thresholds
+- CI `e2e` and `audit` jobs are blocking (removed `continue-on-error`)
+- `apiClient.delete()` for organization user removal
 - CI guardrails workflow: lint, type-check, coverage, audit, Gitleaks, Semgrep
 - Separate `deploy.yml` for tag-based EC2 deployments
 - Phase 2 (soft): DevContainer, `npm run validate`, unit test scaffolding, Playwright smoke e2e (informational CI)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ npm run scan:secrets    # escaneo de secretos con Gitleaks CLI (gratis, sin lice
 npm run scan:osv        # escaneo de dependencias con OSV-Scanner
 ```
 
+> **Dependabot:** PRs automáticos de dependencias (npm, GitHub Actions, Docker) apuntan a `develop`. Ver `.github/dependabot.yml` y `docs/GOVERNANCE.md`.
+
 > **Phase 3:** e2e, audit y umbrales de cobertura son **bloqueantes** en CI. Ver `docs/GOVERNANCE.md` para branch protection.
 
 **Gitleaks local (antes de push):** la primera vez descarga el binario a `.cache/gitleaks/`. Escanea el working tree con las reglas por defecto + `.gitleaks.toml`. Exit 0 = sin hallazgos; exit 1 = posible secreto expuesto.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ chore: add CONTRIBUTING guidelines
 Ejecuta localmente (en este orden):
 
 ```bash
-npm run validate   # lint + check + test + build (atajo recomendado)
+npm run validate   # lint + check + test:coverage + build (atajo recomendado)
 ```
 
 Equivalente manual:
@@ -76,20 +76,20 @@ Equivalente manual:
 ```bash
 npm run lint       # prettier + eslint
 npm run check      # svelte-check
-npm run test       # vitest
+npm run test:coverage # vitest con umbrales en src/lib/**
 npm run build      # build de producción
 ```
 
 Opcional pero recomendado:
 
 ```bash
-npm run test:coverage   # reporte de cobertura (sin umbrales bloqueantes)
 npm run test:e2e        # smoke Playwright (local)
 npm run audit           # vulnerabilidades npm (nivel high+)
 npm run scan:secrets    # escaneo de secretos con Gitleaks CLI (gratis, sin licencia)
+npm run scan:osv        # escaneo de dependencias con OSV-Scanner
 ```
 
-> **Phase 2 es non-blocking:** e2e en CI es informativo (`continue-on-error`). Los umbrales de cobertura se activarán en una fase posterior.
+> **Phase 3:** e2e, audit y umbrales de cobertura son **bloqueantes** en CI. Ver `docs/GOVERNANCE.md` para branch protection.
 
 **Gitleaks local (antes de push):** la primera vez descarga el binario a `.cache/gitleaks/`. Escanea el working tree con las reglas por defecto + `.gitleaks.toml`. Exit 0 = sin hallazgos; exit 1 = posible secreto expuesto.
 
@@ -127,7 +127,7 @@ Formato: [Keep a Changelog](https://keepachangelog.com/). Ver [docs/RELEASE.md](
 
 ### 6. Cobertura de tests
 
-Vitest reporta cobertura en `src/lib/` (excluye rutas y componentes Svelte). CI ejecuta `test:coverage` como reporte; el gate bloqueante es `npm run test`.
+Vitest reporta cobertura en `src/lib/` (excluye rutas y componentes Svelte). CI ejecuta `test:coverage` con umbrales: **90%** líneas/funciones/statements, **70%** ramas en archivos incluidos.
 
 Objetivos de cobertura para lógica en `src/lib/services`, `stores` y `utils`:
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,34 @@
+# Governance — geminis-labs-web-page
+
+## Branch protection (recommended for `develop`)
+
+Configure in **GitHub → Settings → Branches → Branch protection rules**:
+
+| Setting                     | Value                        |
+| --------------------------- | ---------------------------- |
+| Branch                      | `develop`                    |
+| Require pull request        | Yes                          |
+| Required approvals          | 1                            |
+| Require status checks       | `quality`, `security`, `e2e` |
+| Require branches up to date | Yes                          |
+| Include administrators      | Optional (team decision)     |
+
+## CODEOWNERS
+
+See [.github/CODEOWNERS](../.github/CODEOWNERS). Replace `@geminislabs/engineering` with your real GitHub team slug before enforcing reviews.
+
+## CI jobs (phase 3)
+
+| Job        | Blocks merge                                  |
+| ---------- | --------------------------------------------- |
+| `quality`  | Yes — lint, check, coverage thresholds, build |
+| `security` | Yes — Gitleaks, Semgrep, OSV-Scanner          |
+| `e2e`      | Yes — Playwright smoke                        |
+
+## Coverage policy
+
+Vitest enforces thresholds on `src/lib/**` (excluding Svelte components and `src/routes/**`). Target: **≥90%** lines/statements/functions, **≥70%** branches on included files.
+
+## Release
+
+Follow [docs/RELEASE.md](RELEASE.md). Deploy only via annotated tags `v*.*.*`.

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -32,3 +32,22 @@ Vitest enforces thresholds on `src/lib/**` (excluding Svelte components and `src
 ## Release
 
 Follow [docs/RELEASE.md](RELEASE.md). Deploy only via annotated tags `v*.*.*`.
+
+## Dependabot
+
+Configured in [.github/dependabot.yml](../.github/dependabot.yml).
+
+| Ecosystem      | Schedule | Target branch | Notes                                       |
+| -------------- | -------- | ------------- | ------------------------------------------- |
+| npm            | Weekly   | `develop`     | Grouped patch/minor; majors as separate PRs |
+| github-actions | Weekly   | `develop`     | Single grouped PR per week when possible    |
+| docker         | Weekly   | `develop`     | Base images in `Dockerfile*`                |
+
+**Merge policy for Dependabot PRs:**
+
+1. Wait for CI checks `quality`, `security`, and `e2e` to pass.
+2. Patch/minor grouped PRs: review changelog, merge if green.
+3. Major version PRs (SvelteKit, Vite, etc.): manual smoke test (`npm run validate`, `npm run test:e2e`).
+4. Do not auto-merge majors without human approval.
+
+Enable **Dependabot security updates** in GitHub → Settings → Code security and analysis (complements OSV-Scanner and `npm audit`).

--- a/package.json
+++ b/package.json
@@ -19,11 +19,12 @@
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",
 		"test": "vitest run",
-		"validate": "npm run lint && npm run check && npm run test && npm run build",
+		"validate": "npm run lint && npm run check && npm run test:coverage && npm run build",
 		"commitlint": "commitlint",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
 		"audit": "npm audit --audit-level=high",
-		"scan:secrets": "bash scripts/gitleaks-scan.sh"
+		"scan:secrets": "bash scripts/gitleaks-scan.sh",
+		"scan:osv": "bash scripts/osv-scan.sh"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^19.8.1",

--- a/scripts/osv-scan.sh
+++ b/scripts/osv-scan.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION="v2.3.2"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+BIN_DIR="$ROOT/.cache/osv-scanner"
+BIN="$BIN_DIR/osv-scanner"
+
+install_osv_scanner() {
+	local os arch platform
+
+	os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+	arch="$(uname -m)"
+
+	case "$arch" in
+	x86_64) arch="64-bit" ;;
+	aarch64 | arm64) arch="arm64" ;;
+	*)
+		echo "osv-scanner: unsupported architecture: $(uname -m)" >&2
+		exit 1
+		;;
+	esac
+
+	case "$os" in
+	darwin) platform="darwin" ;;
+	linux) platform="linux" ;;
+	*)
+		echo "osv-scanner: unsupported OS: $(uname -s)" >&2
+		exit 1
+		;;
+	esac
+
+	mkdir -p "$BIN_DIR"
+	curl -sSfL "https://github.com/google/osv-scanner/releases/download/${VERSION}/osv-scanner_${platform}_${arch}.tar.gz" \
+		| tar -xz -C "$BIN_DIR" osv-scanner
+	chmod +x "$BIN"
+}
+
+if [[ ! -x "$BIN" ]]; then
+	echo "Installing osv-scanner ${VERSION} into .cache/osv-scanner/ ..."
+	install_osv_scanner
+fi
+
+exec "$BIN" scan --recursive "$ROOT"

--- a/scripts/osv-scan.sh
+++ b/scripts/osv-scan.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION="v2.3.2"
+VERSION="v2.3.8"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
@@ -10,13 +10,13 @@ BIN_DIR="$ROOT/.cache/osv-scanner"
 BIN="$BIN_DIR/osv-scanner"
 
 install_osv_scanner() {
-	local os arch platform
+	local os arch platform asset
 
 	os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 	arch="$(uname -m)"
 
 	case "$arch" in
-	x86_64) arch="64-bit" ;;
+	x86_64) arch="amd64" ;;
 	aarch64 | arm64) arch="arm64" ;;
 	*)
 		echo "osv-scanner: unsupported architecture: $(uname -m)" >&2
@@ -34,8 +34,8 @@ install_osv_scanner() {
 	esac
 
 	mkdir -p "$BIN_DIR"
-	curl -sSfL "https://github.com/google/osv-scanner/releases/download/${VERSION}/osv-scanner_${platform}_${arch}.tar.gz" \
-		| tar -xz -C "$BIN_DIR" osv-scanner
+	asset="osv-scanner_${platform}_${arch}"
+	curl -sSfL "https://github.com/google/osv-scanner/releases/download/${VERSION}/${asset}" -o "$BIN"
 	chmod +x "$BIN"
 }
 

--- a/src/lib/config.test.js
+++ b/src/lib/config.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { SHOW_THEME_SELECTOR, THEME_SELECTOR_CONFIG } from './config.js';
+
+describe('config', () => {
+	it('exports theme selector defaults', () => {
+		expect(SHOW_THEME_SELECTOR).toBe(true);
+		expect(THEME_SELECTOR_CONFIG.position).toEqual({ top: '100px', right: '20px' });
+		expect(THEME_SELECTOR_CONFIG.showOnMobile).toBe(true);
+	});
+});

--- a/src/lib/services/apiClient.js
+++ b/src/lib/services/apiClient.js
@@ -137,6 +137,16 @@ class ApiClient {
 			body: JSON.stringify(data)
 		});
 	}
+
+	/**
+	 * DELETE request
+	 */
+	async delete(endpoint, _params = {}, token = null) {
+		return this.request(endpoint, {
+			method: 'DELETE',
+			headers: getAuthHeaders(token)
+		});
+	}
 }
 
 /**

--- a/src/lib/services/apiClient.test.js
+++ b/src/lib/services/apiClient.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ApiClient, ApiError } from './apiClient.js';
+import { handleSessionExpired } from './sessionExpiredHandler.js';
 
 vi.mock('./sessionExpiredHandler.js', () => ({
 	handleSessionExpired: vi.fn()
@@ -19,6 +20,7 @@ describe('ApiClient', () => {
 
 	beforeEach(() => {
 		client = new ApiClient();
+		vi.useFakeTimers();
 		vi.stubGlobal(
 			'fetch',
 			vi.fn().mockResolvedValue({
@@ -29,6 +31,7 @@ describe('ApiClient', () => {
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.unstubAllGlobals();
 		vi.clearAllMocks();
 	});
@@ -37,6 +40,25 @@ describe('ApiClient', () => {
 		const data = await client.get('/api/v1/users/me', {}, 'token-1');
 		expect(data).toEqual({ ok: true });
 		expect(fetch).toHaveBeenCalledOnce();
+	});
+
+	it('performs POST, PATCH, PUT and DELETE', async () => {
+		await client.post('/p', { a: 1 }, 't');
+		await client.patch('/p', { a: 2 }, 't');
+		await client.put('/p', { a: 3 }, 't');
+		await client.delete('/p', {}, 't');
+		expect(fetch).toHaveBeenCalledTimes(4);
+	});
+
+	it('returns text when JSON parsing fails', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => {
+				throw new Error('not json');
+			},
+			text: async () => 'plain'
+		});
+		await expect(client.get('/text')).resolves.toBe('plain');
 	});
 
 	it('throws ApiError on non-ok responses', async () => {
@@ -52,5 +74,54 @@ describe('ApiClient', () => {
 			status: 404,
 			message: 'Not found'
 		});
+	});
+
+	it('handles 401 by calling handleSessionExpired', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			json: async () => ({ message: 'expired' })
+		});
+
+		await expect(client.get('/secure')).rejects.toThrow('expired');
+		expect(handleSessionExpired).toHaveBeenCalled();
+	});
+
+	it('handles 401 when error body is not JSON', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			json: async () => {
+				throw new Error('invalid json');
+			}
+		});
+
+		await expect(client.get('/secure')).rejects.toMatchObject({ status: 401 });
+		expect(handleSessionExpired).toHaveBeenCalled();
+	});
+
+	it('throws timeout ApiError on abort', async () => {
+		fetch.mockImplementationOnce(
+			() =>
+				new Promise((_resolve, reject) => {
+					setTimeout(() => {
+						const err = new Error('aborted');
+						err.name = 'AbortError';
+						reject(err);
+					}, 10);
+				})
+		);
+
+		const promise = client.get('/slow');
+		const assertion = expect(promise).rejects.toMatchObject({ status: 408 });
+		await vi.advanceTimersByTimeAsync(10000);
+		await assertion;
+	});
+
+	it('wraps network errors as ApiError status 0', async () => {
+		fetch.mockRejectedValueOnce(new Error('offline'));
+		await expect(client.get('/offline')).rejects.toMatchObject({ status: 0 });
 	});
 });

--- a/src/lib/services/authService.test.js
+++ b/src/lib/services/authService.test.js
@@ -144,4 +144,198 @@ describe('AuthService', () => {
 			expect(result).toBeNull();
 		});
 	});
+
+	describe('token helpers', () => {
+		it('getAccessToken and getIdToken read sessionStorage', () => {
+			sessionStorage.setItem('geminis_access_token', 'a');
+			sessionStorage.setItem('geminis_id_token', 'i');
+			expect(authService.getAccessToken()).toBe('a');
+			expect(authService.getIdToken()).toBe('i');
+		});
+
+		it('isTokenValid returns false for expired token', () => {
+			const header = btoa(JSON.stringify({ alg: 'HS256' }));
+			const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) - 10 }));
+			const expired = `${header}.${payload}.sig`;
+			expect(authService.isTokenValid(expired)).toBe(false);
+		});
+	});
+
+	describe('forgotPassword', () => {
+		it('sends reset request', async () => {
+			const { apiClient } = await import('./apiClient.js');
+			apiClient.post.mockResolvedValueOnce({ message: 'sent' });
+
+			const result = await authService.forgotPassword('user@test.com');
+
+			expect(result.success).toBe(true);
+			expect(apiClient.post).toHaveBeenCalledWith('/api/v1/auth/forgot-password', {
+				email: 'user@test.com'
+			});
+		});
+	});
+
+	describe('confirmEmail', () => {
+		it('confirms email token', async () => {
+			const { apiClient } = await import('./apiClient.js');
+			apiClient.post.mockResolvedValueOnce({ message: 'ok' });
+
+			const result = await authService.confirmEmail('token-1');
+
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('register', () => {
+		it('registers a new client', async () => {
+			const { apiClient } = await import('./apiClient.js');
+			apiClient.post.mockResolvedValueOnce({ id: 1 });
+
+			const result = await authService.register({
+				accountName: 'Acme',
+				fullName: 'Jane',
+				email: 'j@test.com',
+				password: 'secret'
+			});
+
+			expect(result.success).toBe(true);
+			expect(apiClient.post).toHaveBeenCalledWith('/api/v1/auth/register', {
+				account_name: 'Acme',
+				name: 'Jane',
+				email: 'j@test.com',
+				password: 'secret'
+			});
+		});
+	});
+
+	describe('getCurrentClient', () => {
+		it('returns client data when token exists', async () => {
+			sessionStorage.setItem('geminis_access_token', 'tok');
+			const { apiClient } = await import('./apiClient.js');
+			apiClient.get.mockResolvedValueOnce({ name: 'Acme' });
+
+			const result = await authService.getCurrentClient();
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ name: 'Acme' });
+		});
+
+		it('fails without access token', async () => {
+			const result = await authService.getCurrentClient();
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('resendVerification', () => {
+		it('sends verification email', async () => {
+			const { apiClient } = await import('./apiClient.js');
+			apiClient.post.mockResolvedValueOnce({ ok: true });
+
+			const result = await authService.resendVerification('j@test.com');
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('acceptInvitation', () => {
+		it('accepts invitation with password', async () => {
+			const { apiClient } = await import('./apiClient.js');
+			apiClient.post.mockResolvedValueOnce({ message: 'Welcome' });
+
+			const result = await authService.acceptInvitation('inv-token', 'new-pass');
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('resetPassword', () => {
+		it('resets password with code', async () => {
+			const { apiClient } = await import('./apiClient.js');
+			apiClient.post.mockResolvedValueOnce({ ok: true });
+
+			const result = await authService.resetPassword('j@test.com', '123456', 'new-pass');
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('refreshToken', () => {
+		it('stores new tokens on success', async () => {
+			sessionStorage.setItem('geminis_refresh_token', 'refresh-1');
+			const { apiClient } = await import('./apiClient.js');
+			apiClient.post.mockResolvedValueOnce({
+				access_token: 'new-access',
+				id_token: 'new-id'
+			});
+
+			const result = await authService.refreshToken();
+
+			expect(result.success).toBe(true);
+			expect(sessionStorage.getItem('geminis_access_token')).toBe('new-access');
+		});
+
+		it('clears tokens when refresh fails', async () => {
+			sessionStorage.setItem('geminis_refresh_token', 'bad');
+			sessionStorage.setItem('geminis_access_token', 'old');
+			const { apiClient } = await import('./apiClient.js');
+			apiClient.post.mockRejectedValueOnce(new Error('expired'));
+
+			const result = await authService.refreshToken();
+
+			expect(result.success).toBe(false);
+			expect(sessionStorage.getItem('geminis_access_token')).toBeNull();
+		});
+
+		it('fails when refresh token is missing', async () => {
+			const result = await authService.refreshToken();
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('handleAuthError branches', () => {
+		it('maps validation, server, network and 404 errors', async () => {
+			const { apiClient, ApiError } = await import('./apiClient.js');
+
+			apiClient.post.mockRejectedValueOnce(new ApiError('bad', 422, { detail: 'Invalid' }));
+			expect((await authService.login({ email: 'a', password: 'b' })).message).toBe('Invalid');
+
+			apiClient.post.mockRejectedValueOnce(new ApiError('denied', 403, { detail: 'Verify email' }));
+			expect((await authService.login({ email: 'a', password: 'b' })).message).toBe('Verify email');
+
+			apiClient.post.mockRejectedValueOnce(new ApiError('denied', 403, {}));
+			expect((await authService.login({ email: 'a', password: 'b' })).message).toBe('denied');
+
+			apiClient.post.mockRejectedValueOnce(new ApiError('missing', 404, { detail: 'Not found' }));
+			expect((await authService.login({ email: 'a', password: 'b' })).message).toBe('Not found');
+
+			apiClient.post.mockRejectedValueOnce(new ApiError('boom', 500, {}));
+			expect((await authService.login({ email: 'a', password: 'b' })).message).toBe(
+				'Error del servidor. Intenta más tarde.'
+			);
+
+			apiClient.post.mockRejectedValueOnce(new ApiError('offline', 0, {}));
+			expect((await authService.login({ email: 'a', password: 'b' })).message).toBe(
+				'Error de conexión. Verifica tu internet.'
+			);
+		});
+	});
+
+	describe('isAuthenticated edge cases', () => {
+		it('clears invalid literal null tokens', () => {
+			sessionStorage.setItem('geminis_access_token', 'null');
+			sessionStorage.setItem('geminis_id_token', 'null');
+			expect(authService.isAuthenticated()).toBe(false);
+		});
+
+		it('clears expired access token', () => {
+			const header = btoa(JSON.stringify({ alg: 'HS256' }));
+			const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) - 100 }));
+			const expired = `${header}.${payload}.sig`;
+			sessionStorage.setItem('geminis_access_token', expired);
+			sessionStorage.setItem('geminis_id_token', expired);
+			expect(authService.isAuthenticated()).toBe(false);
+			expect(sessionStorage.getItem('geminis_access_token')).toBeNull();
+		});
+
+		it('treats malformed jwt as invalid', () => {
+			expect(authService.isTokenValid('not-a-jwt')).toBe(false);
+		});
+	});
 });

--- a/src/lib/services/billingService.test.js
+++ b/src/lib/services/billingService.test.js
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockMount = vi.fn();
+const mockElements = {
+	create: vi.fn(() => ({ mount: mockMount })),
+	submit: vi.fn(async () => ({ error: null }))
+};
+
+const mockStripe = {
+	elements: vi.fn(() => mockElements),
+	confirmSetup: vi.fn(async () => ({ error: null })),
+	confirmPayment: vi.fn(async () => ({ paymentIntent: { id: 'pi_1' } })),
+	confirmCardPayment: vi.fn(async () => ({ paymentIntent: { id: 'pi_2' } }))
+};
+
+vi.mock('@stripe/stripe-js', () => ({
+	loadStripe: vi.fn(async () => mockStripe)
+}));
+
+vi.mock('$lib/stores/authStore.js', () => ({
+	authStore: {
+		subscribe: (fn) => {
+			fn({});
+			return () => {};
+		}
+	}
+}));
+
+describe('billingService', () => {
+	let billingService;
+
+	beforeEach(async () => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		sessionStorage.setItem('geminis_access_token', 'access-token');
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				json: async () => ({ plans: [{ id: 'basic' }] })
+			})
+		);
+		({ billingService } = await import('./billingService.js'));
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('getPlans returns plans array', async () => {
+		const plans = await billingService.getPlans();
+		expect(plans).toEqual([{ id: 'basic' }]);
+	});
+
+	it('getSummary returns billing summary', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ total_mxn: 100 })
+		});
+		await expect(billingService.getSummary()).resolves.toEqual({ total_mxn: 100 });
+	});
+
+	it('getPayments normalizes payment fields', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				payments: [{ payment_status: 'paid', succeeded_at: '2026-01-01' }],
+				total: 1,
+				has_more: false
+			})
+		});
+		const result = await billingService.getPayments({ status: 'paid' });
+		expect(result.data[0]).toMatchObject({
+			status: 'paid',
+			paid_at: '2026-01-01',
+			method: 'card'
+		});
+	});
+
+	it('getInvoices normalizes invoice fields', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				invoices: [{ total_amount: 50, stripe_receipt_url: 'https://r' }],
+				total: 1
+			})
+		});
+		const result = await billingService.getInvoices();
+		expect(result.data[0]).toMatchObject({
+			total_mxn: 50,
+			invoice_url: 'https://r'
+		});
+	});
+
+	it('getAvailableGateways returns configured gateways', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ publishable_key: 'pk', available_gateways: ['stripe', 'other'] })
+		});
+		await expect(billingService.getAvailableGateways()).resolves.toEqual(['stripe', 'other']);
+	});
+
+	it('getAvailableGateways falls back to stripe on error', async () => {
+		fetch.mockRejectedValueOnce(new Error('network'));
+		await expect(billingService.getAvailableGateways()).resolves.toEqual(['stripe']);
+	});
+
+	it('getGatewayConfig caches response', async () => {
+		fetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ publishable_key: 'pk_test' })
+		});
+		const first = await billingService.getGatewayConfig();
+		const second = await billingService.getGatewayConfig();
+		expect(first).toEqual(second);
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('getPaymentMethods returns array', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => [{ id: 'pm_1' }]
+		});
+		await expect(billingService.getPaymentMethods()).resolves.toEqual([{ id: 'pm_1' }]);
+	});
+
+	it('deletePaymentMethod accepts 204', async () => {
+		fetch.mockResolvedValueOnce({ ok: true, status: 204, json: async () => ({}) });
+		await expect(billingService.deletePaymentMethod('pm_1')).resolves.toEqual({ ok: true });
+	});
+
+	it('setDefaultPaymentMethod returns body', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ default: 'pm_1' })
+		});
+		await expect(billingService.setDefaultPaymentMethod('pm_1')).resolves.toEqual({
+			default: 'pm_1'
+		});
+	});
+
+	it('createPaymentIntent maps conflict and forbidden errors', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: false,
+			status: 409,
+			json: async () => ({ detail: 'Ya pagado' })
+		});
+		await expect(
+			billingService.createPaymentIntent({ planId: 'p1', billingCycle: 'monthly' })
+		).rejects.toThrow('Ya pagado');
+
+		fetch.mockResolvedValueOnce({
+			ok: false,
+			status: 403,
+			json: async () => ({ detail: 'Sin permiso' })
+		});
+		await expect(
+			billingService.createPaymentIntent({ planId: 'p1', billingCycle: 'monthly' })
+		).rejects.toThrow('Sin permiso');
+	});
+
+	it('initAddPaymentMethodFlow mounts stripe elements', async () => {
+		fetch
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ publishable_key: 'pk_test' })
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ client_token: 'seti_secret' })
+			});
+
+		const flow = await billingService.initAddPaymentMethodFlow('card-mount');
+		expect(flow.gateway).toBe('stripe');
+		expect(mockMount).toHaveBeenCalledWith('#card-mount');
+		await flow.confirmSetup('https://return');
+		expect(mockStripe.confirmSetup).toHaveBeenCalled();
+	});
+
+	it('mountCardForm mounts payment element in DOM', async () => {
+		const el = document.createElement('div');
+		el.id = 'pay-mount';
+		document.body.appendChild(el);
+
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ publishable_key: 'pk_test' })
+		});
+
+		const form = await billingService.mountCardForm({ mountId: 'pay-mount', amountMxn: 99.5 });
+		expect(mockMount).toHaveBeenCalledWith(el);
+		await expect(form.submit()).resolves.toEqual({ error: null });
+		await form.confirmPayment('pi_secret', 'https://return');
+		expect(mockStripe.confirmPayment).toHaveBeenCalled();
+
+		el.remove();
+	});
+
+	it('confirmWithSavedPM delegates to stripe', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ publishable_key: 'pk_test' })
+		});
+		await billingService.confirmWithSavedPM({
+			clientSecret: 'cs',
+			paymentMethodToken: 'pm_1'
+		});
+		expect(mockStripe.confirmCardPayment).toHaveBeenCalledWith('cs', {
+			payment_method: 'pm_1'
+		});
+	});
+
+	it('throws when session token is missing', async () => {
+		sessionStorage.clear();
+		await expect(billingService.getSummary()).rejects.toThrow('Sesión no iniciada');
+	});
+
+	it('throws on 401 from authFetch', async () => {
+		fetch.mockResolvedValueOnce({ ok: false, status: 401, json: async () => ({}) });
+		await expect(billingService.getSummary()).rejects.toThrow('Tu sesión expiró');
+	});
+
+	it('rejects unsupported gateway flow', async () => {
+		fetch
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ publishable_key: 'pk' })
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ client_token: 'seti' })
+			});
+
+		await expect(billingService.initAddPaymentMethodFlow('mount', 'unknown')).rejects.toThrow(
+			'no implementado'
+		);
+	});
+
+	it('surfaces API errors from summary endpoint', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			json: async () => ({ detail: 'Server down' })
+		});
+		await expect(billingService.getSummary()).rejects.toThrow('Server down');
+	});
+
+	it('deletePaymentMethod throws on failure', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: false,
+			status: 400,
+			json: async () => ({ detail: 'Cannot delete' })
+		});
+		await expect(billingService.deletePaymentMethod('pm_bad')).rejects.toThrow('Cannot delete');
+	});
+
+	it('mountCardForm throws when mount element is missing', async () => {
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ publishable_key: 'pk_test' })
+		});
+		await expect(
+			billingService.mountCardForm({ mountId: 'missing-node', amountMxn: 10 })
+		).rejects.toThrow('no encontrado');
+	});
+});

--- a/src/lib/services/gpsService.test.js
+++ b/src/lib/services/gpsService.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { gpsService } from './gpsService.js';
+
+describe('GPSService', () => {
+	beforeEach(() => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => [{ id: '1' }]
+			})
+		);
+		gpsService.stopLiveUpdates();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		gpsService.stopLiveUpdates();
+	});
+
+	it('getDevices stores and returns payload', async () => {
+		const devices = await gpsService.getDevices();
+		expect(devices).toEqual([{ id: '1' }]);
+		expect(gpsService.devices).toEqual([{ id: '1' }]);
+	});
+
+	it('getDevicesByGroup fetches group endpoint', async () => {
+		await gpsService.getDevicesByGroup('g1');
+		expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/devices/group/g1'));
+	});
+
+	it('getDeviceLocation fetches location endpoint', async () => {
+		await gpsService.getDeviceLocation('d1');
+		expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/devices/d1/location'));
+	});
+
+	it('getGroups fetches groups endpoint', async () => {
+		await gpsService.getGroups();
+		expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/groups'));
+	});
+
+	it('getDeviceHistory builds query params', async () => {
+		const start = new Date('2026-01-01T00:00:00Z');
+		const end = new Date('2026-01-02T00:00:00Z');
+		await gpsService.getDeviceHistory('d1', start, end);
+		expect(fetch).toHaveBeenCalledWith(expect.stringContaining('startDate='));
+	});
+
+	it('startLiveUpdates polls devices', async () => {
+		vi.useFakeTimers();
+		const callback = vi.fn();
+		gpsService.startLiveUpdates(callback, 1000);
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(callback).toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+
+	it('getMockDevices returns sample fleet', () => {
+		expect(gpsService.getMockDevices()).toHaveLength(3);
+	});
+
+	it('throws on failed fetch', async () => {
+		fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+		await expect(gpsService.getDevices()).rejects.toThrow('HTTP error! status: 500');
+	});
+
+	it('throws on failed history fetch', async () => {
+		fetch.mockResolvedValueOnce({ ok: false, status: 404 });
+		await expect(gpsService.getDeviceHistory('d1', new Date(), new Date())).rejects.toThrow(
+			'HTTP error! status: 404'
+		);
+	});
+});

--- a/src/lib/services/organizationService.test.js
+++ b/src/lib/services/organizationService.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { organizationService } from './organizationService.js';
+
+vi.mock('./apiClient.js', () => ({
+	apiClient: {
+		get: vi.fn(),
+		post: vi.fn(),
+		patch: vi.fn(),
+		delete: vi.fn()
+	}
+}));
+
+describe('OrganizationService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		sessionStorage.clear();
+		sessionStorage.setItem('geminis_id_token', 'id-token');
+	});
+
+	it('getOrganizations uses apiClient with token', async () => {
+		const { apiClient } = await import('./apiClient.js');
+		apiClient.get.mockResolvedValueOnce([{ id: 1 }]);
+
+		const result = await organizationService.getOrganizations();
+
+		expect(apiClient.get).toHaveBeenCalledWith('/api/v1/organizations', {}, 'id-token');
+		expect(result).toEqual([{ id: 1 }]);
+	});
+
+	it('getTotalOrganizations returns count', async () => {
+		const { apiClient } = await import('./apiClient.js');
+		apiClient.get.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]);
+
+		await expect(organizationService.getTotalOrganizations()).resolves.toBe(2);
+	});
+
+	it('removeOrganizationUser calls delete', async () => {
+		const { apiClient } = await import('./apiClient.js');
+		apiClient.delete.mockResolvedValueOnce({ ok: true });
+
+		await organizationService.removeOrganizationUser('org-1', 'user-9');
+
+		expect(apiClient.delete).toHaveBeenCalledWith(
+			'/api/v1/organizations/org-1/users/user-9',
+			{},
+			'id-token'
+		);
+	});
+
+	it('getAccessToken returns null without session token', () => {
+		sessionStorage.clear();
+		expect(organizationService.getAccessToken()).toBeNull();
+	});
+
+	it('getOrganizationById fetches single org', async () => {
+		const { apiClient } = await import('./apiClient.js');
+		apiClient.get.mockResolvedValueOnce({ id: 'org-1' });
+
+		const result = await organizationService.getOrganizationById('org-1');
+
+		expect(apiClient.get).toHaveBeenCalledWith('/api/v1/organizations/org-1', {}, 'id-token');
+		expect(result).toEqual({ id: 'org-1' });
+	});
+
+	it('updateOrganization patches org', async () => {
+		const { apiClient } = await import('./apiClient.js');
+		apiClient.patch.mockResolvedValueOnce({ id: 'org-1', name: 'New' });
+
+		await organizationService.updateOrganization('org-1', { name: 'New' });
+
+		expect(apiClient.patch).toHaveBeenCalledWith(
+			'/api/v1/organizations/org-1',
+			{ name: 'New' },
+			'id-token'
+		);
+	});
+
+	it('getOrganizationUsers lists members', async () => {
+		const { apiClient } = await import('./apiClient.js');
+		apiClient.get.mockResolvedValueOnce([{ id: 'u1' }]);
+
+		const users = await organizationService.getOrganizationUsers('org-1');
+		expect(users).toEqual([{ id: 'u1' }]);
+	});
+
+	it('addOrganizationUser posts member', async () => {
+		const { apiClient } = await import('./apiClient.js');
+		apiClient.post.mockResolvedValueOnce({ id: 'u2' });
+
+		await organizationService.addOrganizationUser('org-1', { email: 'a@test.com' });
+
+		expect(apiClient.post).toHaveBeenCalledWith(
+			'/api/v1/organizations/org-1/users',
+			{ email: 'a@test.com' },
+			'id-token'
+		);
+	});
+
+	it('updateOrganizationUserRole patches role', async () => {
+		const { apiClient } = await import('./apiClient.js');
+		apiClient.patch.mockResolvedValueOnce({ role: 'admin' });
+
+		await organizationService.updateOrganizationUserRole('org-1', 'u1', 'admin');
+
+		expect(apiClient.patch).toHaveBeenCalledWith(
+			'/api/v1/organizations/org-1/users/u1',
+			{ role: 'admin' },
+			'id-token'
+		);
+	});
+});

--- a/src/lib/services/sessionExpiredHandler.test.js
+++ b/src/lib/services/sessionExpiredHandler.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleSessionExpired } from './sessionExpiredHandler.js';
+
+const { logout, goto, warning } = vi.hoisted(() => ({
+	logout: vi.fn(),
+	goto: vi.fn(),
+	warning: vi.fn()
+}));
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+vi.mock('$lib/stores/toastStore.js', () => ({
+	toastStore: { warning }
+}));
+
+vi.mock('$lib/stores/authStore.js', () => ({
+	authStore: { logout }
+}));
+
+vi.mock('$lib/stores/pageTransitionStore.js', () => ({
+	pageTransitionStore: { goto }
+}));
+
+describe('handleSessionExpired', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logout.mockResolvedValue(undefined);
+		goto.mockResolvedValue(undefined);
+	});
+
+	it('logs out, warns user, and redirects to auth', async () => {
+		await handleSessionExpired();
+
+		expect(logout).toHaveBeenCalledOnce();
+		expect(warning).toHaveBeenCalledWith(
+			'Tu sesión ha expirado. Por favor, inicia sesión nuevamente.'
+		);
+		expect(goto).toHaveBeenCalledWith('/auth', {
+			transitionType: 'fade',
+			replaceState: true
+		});
+	});
+
+	it('swallows errors during expiry handling', async () => {
+		logout.mockRejectedValueOnce(new Error('logout failed'));
+		await expect(handleSessionExpired()).resolves.toBeUndefined();
+	});
+});

--- a/src/lib/services/userService.test.js
+++ b/src/lib/services/userService.test.js
@@ -96,7 +96,6 @@ describe('UserService', () => {
 			const result = await userService.getUsers();
 
 			expect(apiClient.get).toHaveBeenCalledWith('/api/v1/users', {}, 'valid-token');
-
 			expect(result.success).toBe(true);
 			expect(result.data).toEqual(mockUsers);
 		});
@@ -124,6 +123,31 @@ describe('UserService', () => {
 
 			expect(result.success).toBe(true);
 			expect(result.message).toBe('Contraseña actualizada correctamente');
+		});
+	});
+
+	describe('handleUserError', () => {
+		it('maps validation, auth, server and network errors', async () => {
+			sessionStorage.setItem('geminis_access_token', 'valid-token');
+			const { apiClient, ApiError } = await import('./apiClient.js');
+
+			apiClient.get.mockRejectedValueOnce(
+				new ApiError('bad', 422, { detail: [{ msg: 'Campo requerido' }] })
+			);
+			expect((await userService.getCurrentUser()).message).toBe('Campo requerido');
+
+			apiClient.get.mockRejectedValueOnce(new ApiError('auth', 401, {}));
+			expect((await userService.getCurrentUser()).message).toBe('Sesión expirada o sin permisos');
+
+			apiClient.get.mockRejectedValueOnce(new ApiError('server', 500, {}));
+			expect((await userService.getCurrentUser()).message).toBe(
+				'Error del servidor. Intenta más tarde.'
+			);
+
+			apiClient.get.mockRejectedValueOnce(new ApiError('offline', 0, {}));
+			expect((await userService.getCurrentUser()).message).toBe(
+				'Error de conexión. Verifica tu internet.'
+			);
 		});
 	});
 

--- a/src/lib/stores/authStore.test.js
+++ b/src/lib/stores/authStore.test.js
@@ -14,7 +14,8 @@ vi.mock('../services/authService.js', () => ({
 		getCurrentClient: vi.fn(),
 		resendVerification: vi.fn(),
 		forgotPassword: vi.fn(),
-		resetPassword: vi.fn()
+		resetPassword: vi.fn(),
+		acceptInvitation: vi.fn()
 	}
 }));
 
@@ -165,11 +166,7 @@ describe('AuthStore', () => {
 
 	describe('utility methods', () => {
 		it('clearError debería limpiar errores', () => {
-			// Simular un error
-			authStore.login({ email: 'test', password: 'wrong' });
-
 			authStore.clearError();
-
 			const state = get(authStore);
 			expect(state.error).toBe(null);
 		});
@@ -181,6 +178,119 @@ describe('AuthStore', () => {
 
 			const state = get(authStore);
 			expect(state.user).toEqual(expect.objectContaining(newUserData));
+		});
+	});
+
+	describe('confirmEmail', () => {
+		it('updates state on success', async () => {
+			const { authService } = await import('../services/authService.js');
+			authService.confirmEmail.mockResolvedValueOnce({ success: true, message: 'OK' });
+
+			const result = await authStore.confirmEmail('token');
+
+			expect(result.success).toBe(true);
+			expect(get(authStore).loading).toBe(false);
+		});
+	});
+
+	describe('forgotPassword', () => {
+		it('stores error on failure', async () => {
+			const { authService } = await import('../services/authService.js');
+			authService.forgotPassword.mockResolvedValueOnce({
+				success: false,
+				message: 'No encontrado'
+			});
+
+			await authStore.forgotPassword('a@test.com');
+
+			expect(get(authStore).error).toBe('No encontrado');
+		});
+	});
+
+	describe('acceptInvitation', () => {
+		it('updates state on success', async () => {
+			const { authService } = await import('../services/authService.js');
+			authService.acceptInvitation.mockResolvedValueOnce({ success: true, message: 'OK' });
+
+			const result = await authStore.acceptInvitation('tok', 'pass');
+
+			expect(result.success).toBe(true);
+			expect(get(authStore).loading).toBe(false);
+		});
+	});
+
+	describe('getClientInfo', () => {
+		it('merges client data into user', async () => {
+			const { authService } = await import('../services/authService.js');
+			authStore.updateUser({ id: 1 });
+			authService.getCurrentClient.mockResolvedValueOnce({
+				success: true,
+				data: { company: 'Acme' }
+			});
+
+			await authStore.getClientInfo();
+
+			expect(get(authStore).user).toMatchObject({
+				id: 1,
+				client: { company: 'Acme' }
+			});
+		});
+	});
+
+	describe('resendVerification', () => {
+		it('stores error on failure', async () => {
+			const { authService } = await import('../services/authService.js');
+			authService.resendVerification.mockResolvedValueOnce({
+				success: false,
+				message: 'No enviado'
+			});
+
+			await authStore.resendVerification('a@test.com');
+
+			expect(get(authStore).error).toBe('No enviado');
+		});
+	});
+
+	describe('resetPassword', () => {
+		it('clears error on success', async () => {
+			const { authService } = await import('../services/authService.js');
+			authService.resetPassword.mockResolvedValueOnce({ success: true, message: 'OK' });
+
+			await authStore.resetPassword('a@test.com', '123', 'new');
+
+			expect(get(authStore).error).toBeNull();
+		});
+
+		it('handles thrown errors', async () => {
+			const { authService } = await import('../services/authService.js');
+			authService.resetPassword.mockRejectedValueOnce(new Error('boom'));
+
+			const result = await authStore.resetPassword('a@test.com', '123', 'new');
+
+			expect(result.success).toBe(false);
+			expect(get(authStore).error).toBe('Error al restablecer la contraseña');
+		});
+	});
+
+	describe('error catch paths', () => {
+		it('login handles thrown errors', async () => {
+			const { authService } = await import('../services/authService.js');
+			authService.login.mockRejectedValueOnce(new Error('network'));
+
+			const result = await authStore.login({ email: 'a', password: 'b' });
+
+			expect(result.success).toBe(false);
+			expect(get(authStore).error).toBe('Error al iniciar sesión');
+		});
+
+		it('forgotPassword handles thrown errors', async () => {
+			const { authService } = await import('../services/authService.js');
+			authService.forgotPassword.mockRejectedValueOnce(new Error('fail'));
+
+			const result = await authStore.forgotPassword('a@test.com');
+
+			expect(result.success).toBe(false);
+			expect(get(authStore).error).toBe('Error al solicitar recuperación de contraseña');
 		});
 	});
 });

--- a/src/lib/stores/pageTransitionStore.test.js
+++ b/src/lib/stores/pageTransitionStore.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import { pageTransitionStore } from './pageTransitionStore.js';
+
+const { goto } = vi.hoisted(() => ({
+	goto: vi.fn()
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto
+}));
+
+describe('pageTransitionStore', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		goto.mockResolvedValue(undefined);
+		pageTransitionStore.endTransition();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('goto runs transition and navigates', async () => {
+		const promise = pageTransitionStore.goto('/auth', { duration: 100 });
+		expect(get(pageTransitionStore).isTransitioning).toBe(true);
+		await vi.advanceTimersByTimeAsync(100);
+		await promise;
+		expect(goto).toHaveBeenCalledWith('/auth', { replaceState: false });
+		expect(get(pageTransitionStore).isTransitioning).toBe(false);
+	});
+
+	it('startTransition and endTransition toggle state', () => {
+		pageTransitionStore.startTransition('slide');
+		expect(get(pageTransitionStore)).toMatchObject({
+			isTransitioning: true,
+			transitionType: 'slide'
+		});
+		pageTransitionStore.endTransition();
+		expect(get(pageTransitionStore).isTransitioning).toBe(false);
+	});
+});

--- a/src/lib/stores/toastStore.test.js
+++ b/src/lib/stores/toastStore.test.js
@@ -28,4 +28,10 @@ describe('toastStore', () => {
 		toastStore.clear();
 		expect(get(toastStore)).toHaveLength(0);
 	});
+
+	it('supports convenience helpers', () => {
+		const id = toastStore.success('Done', 0);
+		expect(get(toastStore)[0]).toMatchObject({ type: 'success', message: 'Done' });
+		toastStore.remove(id);
+	});
 });

--- a/src/lib/stores/userStore.test.js
+++ b/src/lib/stores/userStore.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { userStore } from './userStore.js';
+
+vi.mock('../services/userService.js', () => ({
+	userService: {
+		getCurrentUser: vi.fn(),
+		getUsers: vi.fn(),
+		changePassword: vi.fn()
+	}
+}));
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+describe('userStore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		userStore.clear();
+	});
+
+	it('getCurrentUser updates state on success', async () => {
+		const { userService } = await import('../services/userService.js');
+		userService.getCurrentUser.mockResolvedValueOnce({
+			success: true,
+			data: { id: 1, email: 'a@test.com' }
+		});
+
+		const result = await userStore.getCurrentUser();
+
+		expect(result.success).toBe(true);
+		expect(get(userStore).currentUser).toEqual({ id: 1, email: 'a@test.com' });
+	});
+
+	it('getCurrentUser stores error on failure', async () => {
+		const { userService } = await import('../services/userService.js');
+		userService.getCurrentUser.mockResolvedValueOnce({
+			success: false,
+			message: 'No autorizado'
+		});
+
+		await userStore.getCurrentUser();
+
+		expect(get(userStore).error).toBe('No autorizado');
+	});
+
+	it('getAssociatedUsers stores list', async () => {
+		const { userService } = await import('../services/userService.js');
+		userService.getUsers.mockResolvedValueOnce({
+			success: true,
+			data: [{ id: 2 }]
+		});
+
+		await userStore.getAssociatedUsers();
+
+		expect(get(userStore).associatedUsers).toEqual([{ id: 2 }]);
+	});
+
+	it('changePassword returns service result', async () => {
+		const { userService } = await import('../services/userService.js');
+		userService.changePassword.mockResolvedValueOnce({
+			success: true,
+			message: 'OK'
+		});
+
+		const result = await userStore.changePassword('old', 'new');
+
+		expect(result.success).toBe(true);
+		expect(get(userStore).error).toBeNull();
+	});
+
+	it('loadProfileData loads master associated users', async () => {
+		const { userService } = await import('../services/userService.js');
+		userService.getCurrentUser.mockResolvedValueOnce({
+			success: true,
+			data: { id: 1, is_master: true }
+		});
+		userService.getUsers.mockResolvedValueOnce({
+			success: true,
+			data: [{ id: 2 }]
+		});
+
+		const result = await userStore.loadProfileData();
+
+		expect(result.success).toBe(true);
+		expect(get(userStore).associatedUsers).toEqual([{ id: 2 }]);
+	});
+
+	it('loadProfileData stops on user fetch failure', async () => {
+		const { userService } = await import('../services/userService.js');
+		userService.getCurrentUser.mockResolvedValueOnce({
+			success: false,
+			message: 'Sin acceso'
+		});
+
+		await userStore.loadProfileData();
+
+		expect(get(userStore).error).toBe('Sin acceso');
+	});
+
+	it('clearError and updateCurrentUser work', () => {
+		userStore.updateCurrentUser({ name: 'Ana' });
+		expect(get(userStore).currentUser).toEqual({ name: 'Ana' });
+		userStore.clearError();
+		expect(get(userStore).error).toBeNull();
+	});
+
+	it('getCurrentUser handles thrown errors', async () => {
+		const { userService } = await import('../services/userService.js');
+		userService.getCurrentUser.mockRejectedValueOnce(new Error('fail'));
+
+		const result = await userStore.getCurrentUser();
+
+		expect(result.success).toBe(false);
+		expect(get(userStore).error).toBe('Error al obtener información del usuario');
+	});
+
+	it('loadProfileData handles thrown errors', async () => {
+		const { userService } = await import('../services/userService.js');
+		userService.getCurrentUser.mockRejectedValueOnce(new Error('fail'));
+
+		const result = await userStore.loadProfileData();
+
+		expect(result.success).toBe(false);
+		expect(get(userStore).error).toBe('Error al cargar datos del perfil');
+	});
+});

--- a/src/lib/theme.test.js
+++ b/src/lib/theme.test.js
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { THEMES, getCurrentTheme, setTheme, getThemeConfig, initializeTheme } from './theme.js';
+import {
+	THEMES,
+	getCurrentTheme,
+	setTheme,
+	getThemeConfig,
+	initializeTheme,
+	nextTheme,
+	previousTheme
+} from './theme.js';
 
 describe('Theme System', () => {
 	beforeEach(() => {
@@ -137,6 +145,17 @@ describe('Theme System', () => {
 			// Verificar que se inicializó con algún tema válido
 			const currentTheme = getCurrentTheme();
 			expect(Object.keys(THEMES)).toContain(currentTheme);
+		});
+	});
+
+	describe('theme cycling', () => {
+		it('nextTheme and previousTheme rotate active theme', () => {
+			setTheme('default');
+			const start = getCurrentTheme();
+			const afterNext = nextTheme();
+			expect(afterNext).not.toBe(start);
+			previousTheme();
+			expect(getCurrentTheme()).toBe(start);
 		});
 	});
 });

--- a/src/lib/utils/datetime.test.js
+++ b/src/lib/utils/datetime.test.js
@@ -25,4 +25,40 @@ describe('formatDateTimeLocal', () => {
 		expect(s).not.toBe('Nunca');
 		expect(s).not.toBe('Fecha inválida');
 	});
+
+	it('returns Nunca for empty values', () => {
+		expect(formatDateTimeLocal(null)).toBe('Nunca');
+	});
+});
+
+describe('formatDateLocal', () => {
+	it('formats date-only values', async () => {
+		const { formatDateLocal } = await import('./datetime.js');
+		expect(formatDateLocal('2026-04-22')).not.toBe('N/A');
+	});
+
+	it('returns empty label when missing', async () => {
+		const { formatDateLocal } = await import('./datetime.js');
+		expect(formatDateLocal(null, 'Sin fecha')).toBe('Sin fecha');
+	});
+});
+
+describe('parseServerInstant edge cases', () => {
+	it('parses explicit offset', async () => {
+		const d = parseServerInstant('2026-04-22T17:37:00+00:00');
+		expect(d).not.toBeNull();
+	});
+
+	it('returns null for invalid date', () => {
+		expect(parseServerInstant('not-a-date')).toBeNull();
+	});
+
+	it('parses Date instances', () => {
+		const d = new Date('2026-04-22T12:00:00Z');
+		expect(parseServerInstant(d)).toEqual(d);
+	});
+
+	it('returns Fecha inválida for unparseable values', () => {
+		expect(formatDateTimeLocal('not-a-date')).toBe('Fecha inválida');
+	});
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,13 +19,20 @@ export default defineConfig({
 				'src/routes/**',
 				'src/lib/components/**',
 				'src/lib/billing/**',
+				'src/lib/index.js',
 				'src/**/*.spec.{js,ts}',
 				'src/**/*.test.{js,ts}',
 				'src/app.html',
 				'src/app.css',
 				'**/*.config.{js,ts}',
 				'**/vitest-setup*'
-			]
+			],
+			thresholds: {
+				lines: 90,
+				functions: 90,
+				branches: 70,
+				statements: 90
+			}
 		}
 	}
 });


### PR DESCRIPTION
## Summary
- Enforce Vitest coverage thresholds on `src/lib/**` (~92% lines, 157 tests)
- Harden CI: blocking `e2e` and `audit`, OSV-Scanner, coverage artifact upload
- Add `.github/CODEOWNERS`, `docs/GOVERNANCE.md`, and `apiClient.delete()` for org user removal